### PR TITLE
SMT-1206

### DIFF
--- a/swift-sdk.xcodeproj/project.pbxproj
+++ b/swift-sdk.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		AC195210231DAD6B00CD5B61 /* TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00CB31B4210960C4004ACDEC /* TestUtils.swift */; };
 		AC1AA1C624EBB2DC00F29C6B /* IterableTaskRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1AA1C524EBB2DC00F29C6B /* IterableTaskRunner.swift */; };
 		AC1AA1C924EBB3C300F29C6B /* IterableNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1AA1C824EBB3C300F29C6B /* IterableNotifications.swift */; };
+		AC1B29002742579000AD2BE3 /* InAppNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1B28FF2742578F00AD2BE3 /* InAppNavigationTests.swift */; };
 		AC1BED9523F1D4C700FDD75F /* MiscInboxClasses.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1BED9423F1D4C700FDD75F /* MiscInboxClasses.swift */; };
 		AC219C49225FD7EB00B98631 /* IterableInboxViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC219C48225FD7EB00B98631 /* IterableInboxViewController.swift */; };
 		AC219C4D225FE4C000B98631 /* InboxMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC219C4C225FE4C000B98631 /* InboxMessageViewModel.swift */; };
@@ -409,6 +410,7 @@
 		AC1712882416AEF400F2BB0E /* WebViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewProtocol.swift; sourceTree = "<group>"; };
 		AC1AA1C524EBB2DC00F29C6B /* IterableTaskRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IterableTaskRunner.swift; sourceTree = "<group>"; };
 		AC1AA1C824EBB3C300F29C6B /* IterableNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IterableNotifications.swift; sourceTree = "<group>"; };
+		AC1B28FF2742578F00AD2BE3 /* InAppNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppNavigationTests.swift; sourceTree = "<group>"; };
 		AC1BED9423F1D4C700FDD75F /* MiscInboxClasses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiscInboxClasses.swift; sourceTree = "<group>"; };
 		AC219C48225FD7EB00B98631 /* IterableInboxViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IterableInboxViewController.swift; sourceTree = "<group>"; };
 		AC219C4C225FE4C000B98631 /* InboxMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxMessageViewModel.swift; sourceTree = "<group>"; };
@@ -881,6 +883,7 @@
 				55B37FED229F59290042F13A /* InAppPersistenceTests.swift */,
 				55CC257A2462064F00A77FD5 /* InAppPresenterTests.swift */,
 				ACA8D1A821965B7D001B1332 /* InAppTests.swift */,
+				AC1B28FF2742578F00AD2BE3 /* InAppNavigationTests.swift */,
 			);
 			name = "in-app-tests";
 			sourceTree = "<group>";
@@ -1885,6 +1888,7 @@
 				ACD6116E21080564003E7F6B /* IterableAPITests.swift in Sources */,
 				AC02CAA6234E50B5006617E0 /* RegistrationTests.swift in Sources */,
 				ACEDF41F2183C436000B9BFE /* PromiseTests.swift in Sources */,
+				AC1B29002742579000AD2BE3 /* InAppNavigationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/swift-sdk/Internal/DependencyContainer.swift
+++ b/swift-sdk/Internal/DependencyContainer.swift
@@ -43,6 +43,7 @@ extension DependencyContainerProtocol {
                      urlDelegate: config.urlDelegate,
                      customActionDelegate: config.customActionDelegate,
                      urlOpener: urlOpener,
+                     allowedProtocols: config.allowedProtocols,
                      applicationStateProvider: applicationStateProvider,
                      notificationCenter: notificationCenter,
                      dateProvider: dateProvider,

--- a/swift-sdk/Internal/InAppContentParser.swift
+++ b/swift-sdk/Internal/InAppContentParser.swift
@@ -239,10 +239,6 @@ extension HtmlContentParser: ContentFromJsonParser {
             return .failure(reason: "no html")
         }
         
-        guard html.range(of: Const.href, options: [.caseInsensitive]) != nil else {
-            return .failure(reason: "No href tag found in in-app html payload \(html)")
-        }
-        
         let inAppDisplaySettings = json[JsonKey.InApp.inAppDisplaySettings] as? [AnyHashable: Any]
         let padding = getPadding(fromInAppSettings: inAppDisplaySettings)
         

--- a/swift-sdk/Internal/InAppHelper.swift
+++ b/swift-sdk/Internal/InAppHelper.swift
@@ -20,7 +20,7 @@ struct InAppHelper {
         case localResource(name: String) // applewebdata://abc-def/something => something
         case iterableCustomAction(name: String) // iterable://something => something
         case customAction(name: String) // action:something => something or itbl://something => something
-        case regularUrl(URL) // https://something => https://something
+        case regularUrl(URL) // protocol://something => protocol://something
     }
     
     static func parse(inAppUrl url: URL) -> InAppClickedUrl? {

--- a/swift-sdk/Internal/InAppManager.swift
+++ b/swift-sdk/Internal/InAppManager.swift
@@ -36,6 +36,7 @@ class InAppManager: NSObject, IterableInternalInAppManagerProtocol {
          urlDelegate: IterableURLDelegate?,
          customActionDelegate: IterableCustomActionDelegate?,
          urlOpener: UrlOpenerProtocol,
+         allowedProtocols: [String],
          applicationStateProvider: ApplicationStateProviderProtocol,
          notificationCenter: NotificationCenterProtocol,
          dateProvider: DateProviderProtocol,
@@ -51,6 +52,7 @@ class InAppManager: NSObject, IterableInternalInAppManagerProtocol {
         self.urlDelegate = urlDelegate
         self.customActionDelegate = customActionDelegate
         self.urlOpener = urlOpener
+        self.allowedProtocols = allowedProtocols
         self.applicationStateProvider = applicationStateProvider
         self.notificationCenter = notificationCenter
         self.dateProvider = dateProvider
@@ -463,7 +465,8 @@ class InAppManager: NSObject, IterableInternalInAppManagerProtocol {
                                          context: context,
                                          urlHandler: IterableUtil.urlHandler(fromUrlDelegate: self?.urlDelegate, inContext: context),
                                          customActionHandler: IterableUtil.customActionHandler(fromCustomActionDelegate: self?.customActionDelegate, inContext: context),
-                                         urlOpener: self?.urlOpener)
+                                         urlOpener: self?.urlOpener,
+                                         allowedProtocols: self?.allowedProtocols ?? [])
         }
     }
     
@@ -538,6 +541,7 @@ class InAppManager: NSObject, IterableInternalInAppManagerProtocol {
     private let urlDelegate: IterableURLDelegate?
     private let customActionDelegate: IterableCustomActionDelegate?
     private let urlOpener: UrlOpenerProtocol
+    private let allowedProtocols: [String]
     private let applicationStateProvider: ApplicationStateProviderProtocol
     private let notificationCenter: NotificationCenterProtocol
     

--- a/swift-sdk/Internal/InternalIterableAPI.swift
+++ b/swift-sdk/Internal/InternalIterableAPI.swift
@@ -75,7 +75,10 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
     // MARK: - SDK Functions
     
     @discardableResult func handleUniversalLink(_ url: URL) -> Bool {
-        let (result, future) = deepLinkManager.handleUniversalLink(url, urlDelegate: config.urlDelegate, urlOpener: AppUrlOpener())
+        let (result, future) = deepLinkManager.handleUniversalLink(url,
+                                                                   urlDelegate: config.urlDelegate,
+                                                                   urlOpener: AppUrlOpener(),
+                                                                   allowedProtocols: config.allowedProtocols)
         future.onSuccess { attributionInfo in
             if let attributionInfo = attributionInfo {
                 self.attributionInfo = attributionInfo
@@ -546,6 +549,7 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
                                                                                urlDelegate: config.urlDelegate,
                                                                                customActionDelegate: config.customActionDelegate,
                                                                                urlOpener: urlOpener,
+                                                                               allowedProtocols: config.allowedProtocols,
                                                                                inAppNotifiable: inAppManager)
         
         handle(launchOptions: launchOptions)
@@ -592,21 +596,6 @@ final class InternalIterableAPI: NSObject, PushTrackerProtocol, AuthProvider {
         if let pendingUniversalLink = Self.pendingUniversalLink {
             handleUniversalLink(pendingUniversalLink)
             Self.pendingUniversalLink = nil
-        }
-    }
-    
-    private func handleUrl(urlString: String, fromSource source: IterableActionSource) {
-        guard let action = IterableAction.actionOpenUrl(fromUrlString: urlString) else {
-            ITBError("Could not create action from: \(urlString)")
-            return
-        }
-        
-        let context = IterableActionContext(action: action, source: source)
-        DispatchQueue.main.async {
-            IterableActionRunner.execute(action: action,
-                                         context: context,
-                                         urlHandler: IterableUtil.urlHandler(fromUrlDelegate: self.config.urlDelegate, inContext: context),
-                                         urlOpener: self.urlOpener)
         }
     }
     

--- a/swift-sdk/Internal/IterableActionRunner.swift
+++ b/swift-sdk/Internal/IterableActionRunner.swift
@@ -27,7 +27,8 @@ struct IterableActionRunner {
                         context: IterableActionContext,
                         urlHandler: UrlHandler? = nil,
                         customActionHandler: CustomActionHandler? = nil,
-                        urlOpener: UrlOpenerProtocol? = nil) -> Bool {
+                        urlOpener: UrlOpenerProtocol? = nil,
+                        allowedProtocols: [String] = []) -> Bool {
         let handled = callExternalHandlers(action: action,
                                            from: context.source,
                                            urlHandler: urlHandler,
@@ -36,7 +37,9 @@ struct IterableActionRunner {
         if handled {
             return true
         } else {
-            if case let .openUrl(url) = detectActionType(fromAction: action), shouldOpenUrl(url: url, from: context.source), let urlOpener = urlOpener {
+            if case let .openUrl(url) = detectActionType(fromAction: action),
+               shouldOpenUrl(url: url, from: context.source, withAllowedProtocols: allowedProtocols),
+               let urlOpener = urlOpener {
                 urlOpener.open(url: url)
                 return true
             } else {
@@ -71,8 +74,12 @@ struct IterableActionRunner {
         }
     }
     
-    private static func shouldOpenUrl(url: URL, from source: IterableActionSource) -> Bool {
-        if source == .push || source == .inApp, let scheme = url.scheme, scheme == "http" || scheme == "https" {
+    private static func shouldOpenUrl(url: URL,
+                                      from source: IterableActionSource,
+                                      withAllowedProtocols allowedProtocols: [String]) -> Bool {
+        if source == .push || source == .inApp,
+           let scheme = url.scheme,
+           scheme == "https" || allowedProtocols.contains(scheme) {
             return true
         } else {
             return false

--- a/swift-sdk/Internal/IterableAppIntegrationInternal.swift
+++ b/swift-sdk/Internal/IterableAppIntegrationInternal.swift
@@ -126,17 +126,20 @@ struct IterableAppIntegrationInternal {
     private let urlDelegate: IterableURLDelegate?
     private let customActionDelegate: IterableCustomActionDelegate?
     private let urlOpener: UrlOpenerProtocol?
+    private let allowedProtocols: [String]
     private weak var inAppNotifiable: InAppNotifiable?
     
     init(tracker: PushTrackerProtocol,
          urlDelegate: IterableURLDelegate? = nil,
          customActionDelegate: IterableCustomActionDelegate? = nil,
          urlOpener: UrlOpenerProtocol? = nil,
+         allowedProtocols: [String] = [],
          inAppNotifiable: InAppNotifiable) {
         self.tracker = tracker
         self.urlDelegate = urlDelegate
         self.customActionDelegate = customActionDelegate
         self.urlOpener = urlOpener
+        self.allowedProtocols = allowedProtocols
         self.inAppNotifiable = inAppNotifiable
     }
     
@@ -225,7 +228,8 @@ struct IterableAppIntegrationInternal {
                                          context: context,
                                          urlHandler: IterableUtil.urlHandler(fromUrlDelegate: urlDelegate, inContext: context),
                                          customActionHandler: IterableUtil.customActionHandler(fromCustomActionDelegate: customActionDelegate, inContext: context),
-                                         urlOpener: urlOpener)
+                                         urlOpener: urlOpener,
+                                         allowedProtocols: allowedProtocols)
         }
         
         completionHandler?()
@@ -321,7 +325,8 @@ struct IterableAppIntegrationInternal {
                                          context: context,
                                          urlHandler: IterableUtil.urlHandler(fromUrlDelegate: urlDelegate, inContext: context),
                                          customActionHandler: IterableUtil.customActionHandler(fromCustomActionDelegate: customActionDelegate, inContext: context),
-                                         urlOpener: urlOpener)
+                                         urlOpener: urlOpener,
+                                         allowedProtocols: allowedProtocols)
         }
     }
     

--- a/swift-sdk/Internal/IterableDeepLinkManager.swift
+++ b/swift-sdk/Internal/IterableDeepLinkManager.swift
@@ -9,7 +9,10 @@ class IterableDeepLinkManager: NSObject {
     /// For Iterable links, it will track the click and retrieve the original URL,
     /// pass it to `IterableURLDelegate` for handling
     /// If it's not an Iterable link, it just passes the same URL to `IterableURLDelegate`
-    func handleUniversalLink(_ url: URL, urlDelegate: IterableURLDelegate?, urlOpener: UrlOpenerProtocol) -> (Bool, Future<IterableAttributionInfo?, Error>) {
+    func handleUniversalLink(_ url: URL,
+                             urlDelegate: IterableURLDelegate?,
+                             urlOpener: UrlOpenerProtocol,
+                             allowedProtocols: [String] = []) -> (Bool, Future<IterableAttributionInfo?, Error>) {
         if isIterableDeepLink(url.absoluteString) {
             let future = resolve(appLinkURL: url).map { (resolvedUrl, attributionInfo) -> IterableAttributionInfo? in
                 var resolvedUrlString: String
@@ -26,7 +29,8 @@ class IterableDeepLinkManager: NSObject {
                                                  context: context,
                                                  urlHandler: IterableUtil.urlHandler(fromUrlDelegate: urlDelegate,
                                                                                      inContext: context),
-                                                 urlOpener: urlOpener)
+                                                 urlOpener: urlOpener,
+                                                 allowedProtocols: allowedProtocols)
                 }
                 
                 return attributionInfo
@@ -42,7 +46,8 @@ class IterableDeepLinkManager: NSObject {
                                                           context: context,
                                                           urlHandler: IterableUtil.urlHandler(fromUrlDelegate: urlDelegate,
                                                                                               inContext: context),
-                                                          urlOpener: urlOpener)
+                                                          urlOpener: urlOpener,
+                                                          allowedProtocols: allowedProtocols)
                 
                 return (result, Promise<IterableAttributionInfo?, Error>(value: nil))
             } else {

--- a/swift-sdk/IterableConfig.swift
+++ b/swift-sdk/IterableConfig.swift
@@ -116,4 +116,8 @@ public class IterableConfig: NSObject {
     /// will only apply if token-based authentication is enabled, and the current auth token has
     /// an expiration date field in it
     public var expiringAuthTokenRefreshPeriod: TimeInterval = 60.0
+    
+    /// We allow navigation only to urls with `https` protocol (for deep links within your app or external links).
+    /// If you want to allow other protocols, such as,  `http`, `tel` etc., please add them to the list below
+    public var allowedProtocols: [String] = []
 }

--- a/tests/hosting-apps/ui-tests-app/ViewController.swift
+++ b/tests/hosting-apps/ui-tests-app/ViewController.swift
@@ -141,7 +141,7 @@ class ViewController: UIViewController {
         let messageId = "zeeMessageId"
         let html = """
             <body style='height:100px'>
-            <a href="http://website/resource#something">Click Me</a>
+            <a href="https://website/resource#something">Click Me</a>
             <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no'>
             </body>
         """

--- a/tests/ui-tests/UITests.swift
+++ b/tests/ui-tests/UITests.swift
@@ -123,7 +123,7 @@ class UITests: XCTestCase {
     
     // Full Screen
     func testShowInApp5() {
-        inAppTest(buttonName: "Show InApp#5", linkName: "Click Me", expectedCallbackUrl: "http://website/resource#something")
+        inAppTest(buttonName: "Show InApp#5", linkName: "Click Me", expectedCallbackUrl: "https://website/resource#something")
     }
     
     private func inAppTest(buttonName: String, linkName: String, expectedCallbackUrl: String) {

--- a/tests/unit-tests/DeepLinkTests.swift
+++ b/tests/unit-tests/DeepLinkTests.swift
@@ -44,7 +44,7 @@ class DeepLinkTests: XCTestCase {
         
         _ = deepLinkManager.handleUniversalLink(URL(string: iterableRewriteURL)!,
                                                 urlDelegate: mockUrlDelegate,
-                                            urlOpener: MockUrlOpener())
+                                                urlOpener: MockUrlOpener())
         
         wait(for: [expectation1], timeout: testExpectationTimeout)
     }

--- a/tests/unit-tests/InAppNavigationTests.swift
+++ b/tests/unit-tests/InAppNavigationTests.swift
@@ -1,0 +1,138 @@
+//
+//  Copyright © 2021 Iterable. All rights reserved.
+//
+
+import XCTest
+
+@testable import IterableSDK
+
+class InAppNavigationTests: XCTestCase {
+    func testOpenHttpsByDefault() {
+        let expectation1 = expectation(description: #function)
+        let expectation2 = expectation(description: "url opened")
+        
+        let mockInAppFetcher = MockInAppFetcher()
+        
+        let mockInAppDisplayer = MockInAppDisplayer()
+        mockInAppDisplayer.onShow.onSuccess { _ in
+            mockInAppDisplayer.click(url: TestInAppPayloadGenerator.getClickedUrl(protocol: "https", index: 1))
+        }
+        
+        let mockUrlOpener = MockUrlOpener { url in
+            XCTAssertEqual(url, TestInAppPayloadGenerator.getClickedUrl(protocol: "https", index: 1))
+            expectation2.fulfill()
+        }
+        
+        let config = IterableConfig()
+        config.inAppDelegate = MockInAppDelegate(showInApp: .skip)
+        
+        let internalApi = InternalIterableAPI.initializeForTesting(
+            config: config,
+            inAppFetcher: mockInAppFetcher,
+            inAppDisplayer: mockInAppDisplayer,
+            urlOpener: mockUrlOpener
+        )
+        
+        mockInAppFetcher.mockInAppPayloadFromServer(internalApi: internalApi, TestInAppPayloadGenerator.createPayloadWithUrl(numMessages: 1)).onSuccess { [weak internalApi] _ in
+            guard let internalApi = internalApi else {
+                XCTFail("Expected internalApi to be not nil")
+                return
+            }
+            let messages = internalApi.inAppManager.getMessages()
+            
+            internalApi.inAppManager.show(message: messages[0], consume: true) { clickedUrl in
+                XCTAssertEqual(clickedUrl, TestInAppPayloadGenerator.getClickedUrl(protocol: "https", index: 1))
+                expectation1.fulfill()
+            }
+        }
+        
+        wait(for: [expectation1, expectation2], timeout: testExpectationTimeout)
+    }
+
+    func testDoNotOpenHttpByDefault() {
+        let expectation1 = expectation(description: #function)
+        let expectation2 = expectation(description: "url opened")
+        expectation2.isInverted = true
+        
+        let mockInAppFetcher = MockInAppFetcher()
+        
+        let mockInAppDisplayer = MockInAppDisplayer()
+        mockInAppDisplayer.onShow.onSuccess { _ in
+            mockInAppDisplayer.click(url: TestInAppPayloadGenerator.getClickedUrl(protocol: "http", index: 1))
+        }
+        
+        let mockUrlOpener = MockUrlOpener { url in
+            XCTAssertEqual(url, TestInAppPayloadGenerator.getClickedUrl(protocol: "http", index: 1))
+            expectation2.fulfill()
+        }
+        
+        let config = IterableConfig()
+        config.inAppDelegate = MockInAppDelegate(showInApp: .skip)
+        
+        let internalApi = InternalIterableAPI.initializeForTesting(
+            config: config,
+            inAppFetcher: mockInAppFetcher,
+            inAppDisplayer: mockInAppDisplayer,
+            urlOpener: mockUrlOpener
+        )
+        
+        mockInAppFetcher.mockInAppPayloadFromServer(internalApi: internalApi, TestInAppPayloadGenerator.createPayloadWithUrl(numMessages: 1)).onSuccess { [weak internalApi] _ in
+            guard let internalApi = internalApi else {
+                XCTFail("Expected internalApi to be not nil")
+                return
+            }
+            let messages = internalApi.inAppManager.getMessages()
+            
+            internalApi.inAppManager.show(message: messages[0], consume: true) { clickedUrl in
+                XCTAssertEqual(clickedUrl, TestInAppPayloadGenerator.getClickedUrl(protocol: "http", index: 1))
+                expectation1.fulfill()
+            }
+        }
+        
+        wait(for: [expectation1], timeout: testExpectationTimeout)
+        wait(for: [expectation2], timeout: testExpectationTimeoutForInverted)
+    }
+
+    func testAllowHttpWhenAllowedProtocolsIsSet() {
+        let expectation1 = expectation(description: #function)
+        let expectation2 = expectation(description: "url opened")
+        
+        let mockInAppFetcher = MockInAppFetcher()
+        
+        let mockInAppDisplayer = MockInAppDisplayer()
+        mockInAppDisplayer.onShow.onSuccess { _ in
+            mockInAppDisplayer.click(url: TestInAppPayloadGenerator.getClickedUrl(protocol: "http", index: 1))
+        }
+        
+        let mockUrlOpener = MockUrlOpener { url in
+            XCTAssertEqual(url, TestInAppPayloadGenerator.getClickedUrl(protocol: "http", index: 1))
+            expectation2.fulfill()
+        }
+        
+        let config = IterableConfig()
+        config.inAppDelegate = MockInAppDelegate(showInApp: .skip)
+        config.allowedProtocols = ["http"]
+
+        let internalApi = InternalIterableAPI.initializeForTesting(
+            config: config,
+            inAppFetcher: mockInAppFetcher,
+            inAppDisplayer: mockInAppDisplayer,
+            urlOpener: mockUrlOpener
+        )
+        
+        mockInAppFetcher.mockInAppPayloadFromServer(internalApi: internalApi, TestInAppPayloadGenerator.createPayloadWithUrl(numMessages: 1)).onSuccess { [weak internalApi] _ in
+            guard let internalApi = internalApi else {
+                XCTFail("Expected internalApi to be not nil")
+                return
+            }
+            let messages = internalApi.inAppManager.getMessages()
+            
+            internalApi.inAppManager.show(message: messages[0], consume: true) { clickedUrl in
+                XCTAssertEqual(clickedUrl, TestInAppPayloadGenerator.getClickedUrl(protocol: "http", index: 1))
+                expectation1.fulfill()
+            }
+        }
+        
+        wait(for: [expectation1, expectation2], timeout: testExpectationTimeout)
+    }
+}

--- a/tests/unit-tests/TestInAppPayloadGenerator.swift
+++ b/tests/unit-tests/TestInAppPayloadGenerator.swift
@@ -35,8 +35,8 @@ struct TestInAppPayloadGenerator {
         index
     }
     
-    static func getClickedUrl(index: Int) -> URL {
-        URL(string: getClickedLink(index: index))!
+    static func getClickedUrl(protocol: String = "https", index: Int) -> URL {
+        URL(string: getClickedLink(protocol: `protocol`, index: index))!
     }
     
     static func getCustomActionUrl(index: Int) -> URL {
@@ -51,19 +51,45 @@ struct TestInAppPayloadGenerator {
         (campaignId as? Int) ?? -1
     }
     
-    static func createOneInAppDictWithUrl(index: Int, trigger: IterableInAppTrigger?, expiresAt: Date? = nil, saveToInbox: Bool = false) -> [AnyHashable: Any] {
-        createOneInAppDict(withHref: getClickedLink(index: index), index: index, trigger: trigger, expiresAt: expiresAt, saveToInbox: saveToInbox)
+    static func createOneInAppDictWithUrl(protocol: String = "https",
+                                          index: Int,
+                                          trigger: IterableInAppTrigger? = nil,
+                                          expiresAt: Date? = nil,
+                                          saveToInbox: Bool = false) -> [AnyHashable: Any] {
+        createOneInAppDict(withHref: getClickedLink(protocol: `protocol`, index: index),
+                           index: index,
+                           trigger: trigger,
+                           expiresAt: expiresAt,
+                           saveToInbox: saveToInbox)
     }
     
-    static func createOneInAppDictWithUrl(index: Int, triggerType: IterableInAppTriggerType, expiresAt: Date? = nil, saveToInbox: Bool = false) -> [AnyHashable: Any] {
-        createOneInAppDict(withHref: getClickedLink(index: index), index: index, trigger: trigger(fromTriggerType: triggerType), expiresAt: expiresAt, saveToInbox: saveToInbox)
+    static func createOneInAppDictWithUrl(protocol: String = "https",
+                                          index: Int,
+                                          triggerType: IterableInAppTriggerType = .immediate,
+                                          expiresAt: Date? = nil,
+                                          saveToInbox: Bool = false) -> [AnyHashable: Any] {
+        createOneInAppDict(withHref: getClickedLink(protocol: `protocol`, index: index),
+                           index: index,
+                           trigger: trigger(fromTriggerType: triggerType),
+                           expiresAt: expiresAt,
+                           saveToInbox: saveToInbox)
     }
     
-    static func createOneInAppDictWithCustomAction(index: Int, triggerType: IterableInAppTriggerType, saveToInbox: Bool = false) -> [AnyHashable: Any] {
-        createOneInAppDict(withHref: getCustomActionUrl(index: index).absoluteString, index: index, trigger: trigger(fromTriggerType: triggerType), expiresAt: nil, saveToInbox: saveToInbox)
+    static func createOneInAppDictWithCustomAction(index: Int,
+                                                   triggerType: IterableInAppTriggerType = .immediate,
+                                                   saveToInbox: Bool = false) -> [AnyHashable: Any] {
+        createOneInAppDict(withHref: getCustomActionUrl(index: index).absoluteString,
+                           index: index,
+                           trigger: trigger(fromTriggerType: triggerType),
+                           expiresAt: nil,
+                           saveToInbox: saveToInbox)
     }
     
-    private static func createOneInAppDict(withHref href: String, index: Int, trigger: IterableInAppTrigger?, expiresAt: Date?, saveToInbox: Bool = false) -> [AnyHashable: Any] {
+    private static func createOneInAppDict(withHref href: String,
+                                           index: Int,
+                                           trigger: IterableInAppTrigger?,
+                                           expiresAt: Date?,
+                                           saveToInbox: Bool = false) -> [AnyHashable: Any] {
         var dict = createOneInAppDict(withHref: href, index: index)
         if let expiresAt = expiresAt {
             dict["expiresAt"] = IterableUtil.int(fromDate: expiresAt)
@@ -101,7 +127,8 @@ struct TestInAppPayloadGenerator {
         IterableInAppTrigger(dict: ["type": String(describing: triggerType)])
     }
     
-    private static func getClickedLink(index: Int) -> String {
-        "https://www.site\(index).com"
+    private static func getClickedLink(protocol: String = "https",
+                                       index: Int) -> String {
+        "\(`protocol`)://www.site\(index).com"
     }
 }


### PR DESCRIPTION
## 🔹 Jira Ticket(s)

* [SMT-1206](https://freecast.atlassian.net/browse/SMT-1206)

## ✏️ Point the app to our fork of the Iterable SDK

> This PR contains a fix to create In-App Messages even if the message does not have an `href` link, this way it could be created just using a simple string.
The branch was also updated with the based Iterable repository.

This is the only change I made:
https://github.com/FreeCastInc/Iterable/commit/5c488e9efee43c64df57fdeded103fdc99cb6166